### PR TITLE
Changing assigness should show the save button

### DIFF
--- a/src/js/heart/Issue.js
+++ b/src/js/heart/Issue.js
@@ -41,7 +41,7 @@ _.extend(Issue.prototype, {
     save: function() {
         var d = {
             milestone: this.milestoneNumber(),
-            assignee: this.assignee() && this.assignee().login()
+            assignee: this.assignee() && this.assignee().login() || null
         };
 
         return github.patch(this.url(), d);


### PR DESCRIPTION
Currently changing assignees saves an issue immediately. This change
will instead make the save/revert buttons appear so changing users
has the same semantics as moving issues around.

Fixes #22