### PR TITLE
Handle new milestones correctly

### DIFF
--- a/src/js/heart/IssueStorage.js
+++ b/src/js/heart/IssueStorage.js
@@ -25,7 +25,7 @@ _.extend(IssueStorage.prototype, {
         return this.getFileInfo(this.branch, this.githubFilePath)
             .then(function(fileInfo) {
                 this.issuesByMilestone = JSON.parse(atob(fileInfo.content));
-                return this.issuesByMilestone[milestone.number()];
+                return this.issuesByMilestone[milestone.number()] || [];
             }.bind(this))
             .catch(function(err) {
                 log.warn('No config file for ', this.githubFilePath, err);


### PR DESCRIPTION
When new milestones are added, they won't have an entry in the saved
JSON file. When we create `IssueViews` we expect an array so account
for that.